### PR TITLE
Map Valora's returned address to wallet address

### DIFF
--- a/packages/example/next-env.d.ts
+++ b/packages/example/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -1,11 +1,8 @@
-import '../styles/global.css';
 import '@celo-tools/use-contractkit/lib/styles.css';
+import '../styles/global.css';
 
 import { ContractKitProvider } from '@celo-tools/use-contractkit';
-import {
-  AppComponent,
-  AppProps,
-} from 'next/dist/next-server/lib/router/router';
+import { AppComponent, AppProps } from 'next/dist/shared/lib/router/router';
 import { Toaster } from 'react-hot-toast';
 
 const MyApp: AppComponent = ({ Component, pageProps }: AppProps) => {
@@ -15,6 +12,7 @@ const MyApp: AppComponent = ({ Component, pageProps }: AppProps) => {
         name: 'use-contractkit demo',
         description: 'A demo DApp to showcase functionality',
         url: 'https://use-contractkit.vercel.app',
+        icon: 'https://use-contractkit.vercel.app/favicon.ico',
       }}
     >
       <Toaster

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -299,15 +299,25 @@ export class WalletConnectConnector implements Connector {
 
     if (uri && this.autoOpen) {
       const deepLink = this.getDeeplinkUrl ? this.getDeeplinkUrl(uri) : uri;
-      window.open(deepLink);
+      location.href = deepLink;
     }
 
     await wallet.init();
-    const [defaultAccount] = wallet.getAccounts();
+    const [address] = wallet.getAccounts();
+    const defaultAccount =
+      (await this.fetchWalletAddressForAccount(address)) ?? address;
     this.kit.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
 
     return this;
+  }
+
+  private async fetchWalletAddressForAccount(address?: string) {
+    if (!address) {
+      return undefined;
+    }
+    const accounts = await this.kit.contracts.getAccounts();
+    return accounts.getWalletAddress(address);
   }
 
   close(): Promise<void> {

--- a/packages/use-contractkit/src/contract-kit-reducer.ts
+++ b/packages/use-contractkit/src/contract-kit-reducer.ts
@@ -28,8 +28,11 @@ export function contractKitReducer(
       if (action.payload.name !== state.network.name) {
         const ConnectorConstructor = CONNECTOR_TYPES[state.connector.type];
 
+        const lastArgs = localStorage.getItem(
+          localStorageKeys.lastUsedWalletArguments
+        );
         const connectorArgs = JSON.parse(
-          localStorage.getItem(localStorageKeys.lastUsedWalletArguments) || '[]'
+          lastArgs && lastArgs !== 'undefined' ? lastArgs : '[]'
         ) as unknown[];
         const connector = new ConnectorConstructor(
           action.payload,


### PR DESCRIPTION
There was a bug recently which caused Valora tu return the account address of users instead of the wallet address. There's a PR to fix this [in Valora's repo](https://github.com/valora-inc/wallet/pull/1074) but we still need to handle this case for users running older versions of the app. This PR tries to call the Accounts contract to map to wallet address in case the address returned has a wallet address linked.

Aside from that, fixed two small other issues:
- Open the deeplink in the same tab, not another one. Popups are blocked with Safari so this wasn't working.
- Sometimes the text string 'undefined' was being stored in localStorage. I added a check in one place but we still need to make sure it's not happening elsewhere.